### PR TITLE
Expose nonce number

### DIFF
--- a/Noise-C/include/noise/protocol/cipherstate.h
+++ b/Noise-C/include/noise/protocol/cipherstate.h
@@ -49,6 +49,7 @@ int noise_cipherstate_decrypt_with_ad
 int noise_cipherstate_encrypt(NoiseCipherState *state, NoiseBuffer *buffer);
 int noise_cipherstate_decrypt(NoiseCipherState *state, NoiseBuffer *buffer);
 int noise_cipherstate_set_nonce(NoiseCipherState *state, uint64_t nonce);
+uint64_t noise_cipherstate_get_nonce(const NoiseCipherState *state);
 int noise_cipherstate_get_max_key_length(void);
 int noise_cipherstate_get_max_mac_length(void);
 

--- a/Noise-C/src/protocol/cipherstate.c
+++ b/Noise-C/src/protocol/cipherstate.c
@@ -534,6 +534,11 @@ int noise_cipherstate_set_nonce(NoiseCipherState *state, uint64_t nonce)
     return NOISE_ERROR_NONE;
 }
 
+uint64_t noise_cipherstate_get_nonce(const NoiseCipherState *state)
+{
+    return state ? state->n : 0;
+}
+
 /**
  * \brief Gets the maximum key length for the supported algorithms.
  *

--- a/Noise/State/NPFCipherState.h
+++ b/Noise/State/NPFCipherState.h
@@ -17,6 +17,7 @@ NS_SWIFT_NAME(NoiseCipherState)
 - (NSData *__nullable)decrypt:(NSData *)data error:(NSError * _Nullable __autoreleasing *)error;
 
 - (NSUInteger)macLength;
+- (int64_t)nonce;
 
 @end
 

--- a/Noise/State/NPFCipherState.m
+++ b/Noise/State/NPFCipherState.m
@@ -95,4 +95,9 @@
     return noise_cipherstate_get_mac_length(_cipherState);
 }
 
+- (int64_t)nonce
+{
+    return noise_cipherstate_get_nonce(_cipherState);
+}
+
 @end


### PR DESCRIPTION
Hi,

**Motivation:**
In my project it was required to have the nonce number for the current cipher state. Otherwise it was not possible to perform successful handshake.
**What was done:**
Exposed nonce number for the current cipher state from the noise-c library by adding simple function implementation and headers.

Thank you.